### PR TITLE
docs: add community-health basics (dependabot, templates, CODEOWNERS, contributing)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @neverDefined

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,82 @@
+name: Bug report
+description: Report a defect in go-anvil.
+title: "[bug] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please fill in the fields below so the issue is actionable.
+
+  - type: input
+    id: go-version
+    attributes:
+      label: Go version
+      description: Output of `go version`.
+      placeholder: "go version go1.25.0 darwin/arm64"
+    validations:
+      required: true
+
+  - type: input
+    id: anvil-version
+    attributes:
+      label: Foundry / anvil version
+      description: Output of `anvil --version`.
+      placeholder: "anvil Version: 1.5.0-stable"
+    validations:
+      required: true
+
+  - type: input
+    id: go-anvil-version
+    attributes:
+      label: go-anvil version / commit
+      description: Module version pinned in go.mod, or commit SHA.
+      placeholder: "v0.1.0 or 5ae0d5c"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - Other (specify in reproduction)
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: Runnable Go snippet or repo link that reproduces the issue.
+      render: go
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: Include error messages and stack traces verbatim.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Additional logs or anvil output
+      description: Paste any relevant anvil stderr or verbose log output.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Foundry (upstream anvil) documentation
+    url: https://book.getfoundry.sh/anvil/
+    about: Questions about anvil itself (flags, RPC methods, behaviour) belong upstream, not here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature request
+description: Propose a new capability or API for go-anvil.
+title: "[feature] "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing, check the pinned roadmap issue to see whether this is already tracked.
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: What problem does this solve, and for whom?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed API or behaviour
+      description: Sketch the method signature, builder option, or behavioural change.
+      render: go
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What have you tried, and why is this the right shape?
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope check
+      options:
+        - label: This is about wrapping anvil — not about adding a second execution client, node type, or unrelated blockchain tooling.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!-- Link the issue this PR closes. Use `Closes #N` for each. -->
+Closes #
+
+## Summary
+
+<!-- 1–3 bullets describing what changes and why. -->
+-
+
+## Test plan
+
+<!-- Check off what you ran. `go test -race ./...` requires anvil on PATH. -->
+- [ ] `go build ./...` clean
+- [ ] `go vet ./...` clean
+- [ ] `golangci-lint run` clean
+- [ ] `go test -race ./...` green
+- [ ] Godoc updated for any new or changed exported identifiers
+- [ ] `CHANGELOG.md` entry added (if user-visible change)
+
+## Notes for reviewer
+
+<!-- Breaking changes, follow-ups, edge cases to look at. Remove if none. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: UTC
+    open-pull-requests-limit: 5
+    groups:
+      gomod-minor-patch:
+        update-types:
+          - minor
+          - patch
+    ignore:
+      - dependency-name: github.com/ethereum/go-ethereum
+        update-types:
+          - version-update:semver-major
+    labels:
+      - area:ci
+      - type:chore
+    commit-message:
+      prefix: chore(deps)
+      include: scope
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: UTC
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-patch:
+        update-types:
+          - minor
+          - patch
+    labels:
+      - area:ci
+      - type:chore
+    commit-message:
+      prefix: chore(ci)
+      include: scope

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing to go-anvil
+
+Thanks for your interest. This is a solo-maintained library, so PRs and issues are reviewed on a best-effort basis.
+
+## Prerequisites
+
+- Go 1.25 or later (matches `go.mod`)
+- [Foundry](https://book.getfoundry.sh/) — tests spawn real `anvil` processes
+- `make`
+
+Install the Go toolchain helpers once:
+
+```
+make install-tools
+```
+
+## Local workflow
+
+The single command to run before pushing:
+
+```
+make check
+```
+
+That wraps `fmt`, `vet`, `lint` (golangci-lint against the repo's `.golangci.yml`), and `test` (with `-race`).
+
+Individual targets if you want to run them in isolation:
+
+```
+make fmt          # gofmt / gofumpt
+make vet          # go vet
+make lint         # golangci-lint run
+make test         # go test -race ./...
+make test-coverage # HTML coverage report
+```
+
+Tests require `anvil` on `PATH`. If you don't have Foundry installed, `make check-foundry` will tell you so.
+
+## Branch naming
+
+Use a prefix that reflects the nature of the change. Examples:
+
+- `feat/context-first-rpc-methods`
+- `fix/startup-timeout-race`
+- `chore/bump-foundry-1.6`
+- `docs/examples-fork-scenario`
+- `ci/add-govulncheck`
+
+## Commit style
+
+Use [Conventional Commits](https://www.conventionalcommits.org/). Examples:
+
+```
+feat(api): add SetCoinbase RPC wrapper
+fix(startup): replace 2s sleep with readiness probe
+chore(deps): bump go-ethereum to v1.18.0
+docs(readme): document snapshot/revert pattern
+```
+
+The scope is optional but helpful. Breaking changes go under `feat!:` / `fix!:` or include a `BREAKING CHANGE:` footer.
+
+## Pull requests
+
+Every PR should:
+
+1. Close an issue — put `Closes #N` at the top of the body. If an issue doesn't exist yet, file one first (the maintainer tracks all work via issues).
+2. Pass the PR template checklist (tests, lint, godoc, CHANGELOG if user-visible).
+3. Keep the diff focused. If you're also fixing an unrelated nit, file a separate PR.
+4. Not amend or force-push after review has started, unless asked.
+
+## Godoc
+
+Every exported identifier must have a godoc comment starting with the identifier name. `make lint` (via `revive`) enforces this.
+
+## Changelog
+
+User-visible changes go in `CHANGELOG.md` under `## [Unreleased]` in Keep-a-Changelog form (`Added` / `Changed` / `Fixed` / `Removed`). Maintainer-only chores don't need an entry.


### PR DESCRIPTION
Replaces the closed PR #28 with a narrower scope — same work minus \`SECURITY.md\` and \`CODE_OF_CONDUCT.md\`, which the maintainer scoped out (#13 and #15 closed as not-planned).

## Summary

- `.github/dependabot.yml` — weekly gomod + github-actions updates, minor/patch grouped, ignore go-ethereum majors.
- `.github/ISSUE_TEMPLATE/{bug_report,feature_request,config}.yml` — structured forms; disable blank issues; route upstream anvil questions to the Foundry book.
- `.github/PULL_REQUEST_TEMPLATE.md` — tests / lint / godoc / CHANGELOG checklist.
- `.github/CODEOWNERS` — \`* @neverDefined\`.
- `CONTRIBUTING.md` — local workflow, branch/commit conventions (introduces Conventional Commits for Phase 2 release automation).

## Test plan

- [ ] Opening a new issue via the web UI offers **Bug report** / **Feature request** structured forms (blank issues disabled).
- [ ] Opening a new PR pre-fills the checklist.
- [ ] `gh api repos/neverDefined/go-anvil/community/profile --jq '.files | to_entries[] | select(.value != null) | .key'` lists \`contributing\`, \`issue_template\`, \`pull_request_template\`, \`license\`, \`readme\` (security_policy and code_of_conduct intentionally absent).
- [ ] Dependabot opens its first batch of PRs within ~24h of merge (assuming updates are available).

## Scope notes

- No SECURITY.md, no CODE_OF_CONDUCT.md — issues #13 and #15 closed as not-planned.
- No `.github/FUNDING.yml` — left for later if ever desired.
- No code changes.

Closes #22
Closes #23
Closes #24
Closes #25

## Follow-ups

Phase 1 PR B (next): pin Foundry version (#20), CI hardening with -race/govulncheck/golangci-lint (#26), Claude bootstrap CLAUDE.md + settings (#21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)