### PR TITLE
feat!: migrate RPC methods to context-first signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Start()` method no longer takes timeout parameter (uses internal retry logic)
 - **BREAKING**: `Reset()` method replaced with `ResetState()` that uses RPC instead of process restart
 - Test suite now uses shared Anvil instance with `ResetState()` between tests (much faster)
+- **BREAKING**: All mutating RPC methods now take `context.Context` as their first parameter.
+  Callers gain cancellation and timeout support on every RPC call; a hung RPC no longer blocks
+  the caller indefinitely. Affected methods: `MineBlock`, `SetNextBlockTimestamp`, `IncreaseTime`,
+  `SetBalance`, `Impersonate`, `StopImpersonating`, `Snapshot`, `Revert`, `SetCode`,
+  `SetStorageAt`, `SetNonce`, `Mine`, `DropTransaction`, `SetAutomine`, `SetIntervalMining`,
+  `AutoImpersonate`, `ResetFork`, `ResetState`. The `EthereumTestEnvironment` interface is
+  updated to match.
+
+  Migration:
+  ```go
+  // before
+  anvil.MineBlock()
+  anvil.SetBalance(addr, bal)
+
+  // after
+  ctx := context.Background() // or t.Context() in tests, or a ctx with timeout
+  anvil.MineBlock(ctx)
+  anvil.SetBalance(ctx, addr, bal)
+  ```
+
+### Added
+- `(*Anvil).WaitForMemPoolEmpty(ctx, timeout)` — replaces the free function `MemPoolEmpty`
+  with a context-aware method that respects both the caller's ctx deadline and an explicit
+  timeout.
+
+### Deprecated
+- Free function `MemPoolEmpty(ctx, client)` — use `(*Anvil).WaitForMemPoolEmpty` instead.
+  Will be removed in a future release.
 
 ### Fixed
 - Duplicate test function "Test Reset Functionality" removed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Guidance for Claude Code when working in this repo. Read this first — it captu
 
 - `anvil.go` — all public API, lifecycle (spawn subprocess + RPC client), builder.
 - `anvil_test.go` — all tests. Integration-only; require `anvil` on `PATH`.
-- `helpers.go` — small utilities (e.g. `MemPoolEmpty`).
+- `helpers.go` — small utilities (e.g. `(*Anvil).WaitForMemPoolEmpty`).
 
 Module path: `github.com/neverDefined/go-anvil`.
 
@@ -27,7 +27,18 @@ If `anvil` isn't on `PATH`, `make check-foundry` tells you.
 
 **Shared-anvil test pattern.** Tests reuse a single `*Anvil` instance via `setupSharedAnvil(t, sharedAnvil)` (see `anvil_test.go`). `ResetState()` between subtests uses snapshot/revert rather than process restart — ~10× faster than spawning a new anvil per test. Only drop to `setupTestAnvil(t, cfg)` when a test truly needs custom config (e.g. forking from a specific URL). Do not introduce new top-level `anvil.NewAnvil()` calls inside test subtests.
 
-**RPC method shape — pending migration.** Mutating RPC methods (`SetBalance`, `Impersonate`, `MineBlock`, `Snapshot`, `SetCode`, `SetStorageAt`, `SetNonce`, `DropTransaction`, `SetAutomine`, etc.) currently call `a.rpcClient.Call(nil, ...)` with a `nil` context. Phase 2 of the roadmap migrates the whole set to context-first signatures in one batch as a breaking pre-1.0 bump. Do not change individual methods in isolation — it'll fragment the API and churn the CHANGELOG twice.
+**RPC methods are context-first.** Every mutating RPC method takes `ctx context.Context` as its first parameter and forwards to `a.rpcClient.CallContext(ctx, ...)`. Do not regress to bare `Call(nil, ...)` — it removes cancellation and timeout support for callers. When adding a new RPC wrapper, follow this shape:
+
+```go
+func (a *Anvil) SetFoo(ctx context.Context, arg T) error {
+    a.rpcCalls.Add(1)
+    if err := a.rpcClient.CallContext(ctx, nil, "anvil_setFoo", arg); err != nil {
+        a.logger.Error().Err(err).Str("arg", fmt.Sprint(arg)).Msg("Failed to set foo")
+        return err
+    }
+    return nil
+}
+```
 
 **Builder pattern.** All `With*` methods are setters that return `*AnvilBuilder` for chaining; they don't validate. Validation lives in `Build()` (`validate()` is called at the top). When adding a new option, follow this split.
 

--- a/README.md
+++ b/README.md
@@ -32,33 +32,37 @@ go get github.com/neverDefined/go-anvil
 package main
 
 import (
+    "context"
     "log"
-    "math/big"
-    
+
     "github.com/neverDefined/go-anvil"
-    "github.com/ethereum/go-ethereum/common"
 )
 
 func main() {
+    ctx := context.Background()
+
     // Create and start an Anvil instance
     anvil, err := anvil.NewAnvil()
     if err != nil {
         log.Fatal(err)
     }
-    
-    err = anvil.Start()
-    if err != nil {
+
+    if err := anvil.Start(); err != nil {
         log.Fatal(err)
     }
     defer anvil.Close()
-    
-    // Get Ethereum clients
-    ethClient := anvil.Client()
-    rpcClient := anvil.RPCClient()
-    
-    // Use the clients for testing
-    blockNumber, _ := ethClient.BlockNumber(context.Background())
+
+    // Query the chain via the Ethereum client
+    blockNumber, err := anvil.Client().BlockNumber(ctx)
+    if err != nil {
+        log.Fatal(err)
+    }
     log.Printf("Current block: %d", blockNumber)
+
+    // Drive Anvil's RPC with context-first methods
+    if err := anvil.MineBlock(ctx); err != nil {
+        log.Fatal(err)
+    }
 }
 ```
 
@@ -93,18 +97,22 @@ anvil, err := anvil.NewAnvilBuilder().
 
 ## Usage Examples
 
+Every mutating RPC method takes a `context.Context` as its first argument. Tests can use `t.Context()`; production callers should use their request context or `context.Background()` with a deadline.
+
 ### Block Mining
 
 ```go
+ctx := context.Background()
+
 // Mine a single block
-err := anvil.MineBlock()
+err := anvil.MineBlock(ctx)
 
 // Mine multiple blocks
-err = anvil.Mine(5, 0)  // Mine 5 blocks with default timestamps
+err = anvil.Mine(ctx, 5, 0)  // Mine 5 blocks with default timestamps
 
 // Mine with specific timestamp
 timestamp := uint64(time.Now().Unix())
-err = anvil.Mine(1, timestamp)
+err = anvil.Mine(ctx, 1, timestamp)
 
 // Wait for a specific block
 err = anvil.WaitForBlock(10, 5*time.Second)
@@ -114,10 +122,10 @@ err = anvil.WaitForBlock(10, 5*time.Second)
 
 ```go
 // Increase time by 1 hour
-err := anvil.IncreaseTime(3600)
+err := anvil.IncreaseTime(ctx, 3600)
 
 // Set timestamp for next block
-err = anvil.SetNextBlockTimestamp(time.Now().Unix())
+err = anvil.SetNextBlockTimestamp(ctx, time.Now().Unix())
 ```
 
 ### Account Management
@@ -128,48 +136,48 @@ keys, addresses, err := anvil.Accounts()
 
 // Set account balance
 address := common.HexToAddress("0x...")
-err = anvil.SetBalance(address, big.NewInt(1e18))  // 1 ETH
+err = anvil.SetBalance(ctx, address, big.NewInt(1e18))  // 1 ETH
 
 // Impersonate an account (send transactions without private key)
-err = anvil.Impersonate(address)
+err = anvil.Impersonate(ctx, address)
 // ... send transactions as this address
-err = anvil.StopImpersonating(address)
+err = anvil.StopImpersonating(ctx, address)
 
 // Set account nonce
-err = anvil.SetNonce(address, 42)
+err = anvil.SetNonce(ctx, address, 42)
 ```
 
 ### State Management
 
 ```go
 // Reset to initial state (fast - uses RPC)
-err := anvil.ResetState()
+err := anvil.ResetState(ctx)
 
 // Create a snapshot
-snapshotID, err := anvil.Snapshot()
+snapshotID, err := anvil.Snapshot(ctx)
 
 // Revert to snapshot
-success, err := anvil.Revert(snapshotID)
+success, err := anvil.Revert(ctx, snapshotID)
 ```
 
 ### Advanced Operations
 
 ```go
 // Set bytecode at address
-err := anvil.SetCode(address, "0x6080604052...")
+err := anvil.SetCode(ctx, address, "0x6080604052...")
 
 // Modify storage slot
-err = anvil.SetStorageAt(address, slot, value)
+err = anvil.SetStorageAt(ctx, address, slot, value)
 
 // Control mining
-err = anvil.SetAutomine(false)  // Disable automatic mining
-err = anvil.SetIntervalMining(5)  // Mine every 5 seconds
+err = anvil.SetAutomine(ctx, false)  // Disable automatic mining
+err = anvil.SetIntervalMining(ctx, 5)  // Mine every 5 seconds
 
 // Enable auto-impersonation
-err = anvil.AutoImpersonate(true)
+err = anvil.AutoImpersonate(ctx, true)
 
 // Drop pending transaction
-err = anvil.DropTransaction(txHash)
+err = anvil.DropTransaction(ctx, txHash)
 ```
 
 ### Metrics
@@ -194,12 +202,12 @@ func TestMyContract(t *testing.T) {
     
     t.Run("test case 1", func(t *testing.T) {
         // Reset state before each test
-        anvil.ResetState()
+        anvil.ResetState(t.Context())
         // ... your test
     })
     
     t.Run("test case 2", func(t *testing.T) {
-        anvil.ResetState()
+        anvil.ResetState(t.Context())
         // ... your test
     })
 }

--- a/anvil.go
+++ b/anvil.go
@@ -91,29 +91,31 @@ var AnvilPrivateKeys = [...]AnvilPrivateKey{
 	"5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a",
 }
 
-// EthereumTestEnvironment defines the interface for Ethereum test environments
+// EthereumTestEnvironment defines the interface for Ethereum test environments.
+// Mutating RPC methods take a context.Context as the first parameter for cancellation
+// and timeout support.
 type EthereumTestEnvironment interface {
-	Start(timeout time.Duration) error
+	Start() error
 	Stop() error
 	Client() *ethclient.Client
 	RPCClient() *rpc.Client
-	MineBlock() error
-	SetNextBlockTimestamp(timestamp int64) error
-	IncreaseTime(seconds int64) error
-	SetBalance(address common.Address, balance *big.Int) error
-	Impersonate(address common.Address) error
-	StopImpersonating(address common.Address) error
+	MineBlock(ctx context.Context) error
+	SetNextBlockTimestamp(ctx context.Context, timestamp int64) error
+	IncreaseTime(ctx context.Context, seconds int64) error
+	SetBalance(ctx context.Context, address common.Address, balance *big.Int) error
+	Impersonate(ctx context.Context, address common.Address) error
+	StopImpersonating(ctx context.Context, address common.Address) error
 }
 
 // Anvil represents a local Ethereum test environment
 type Anvil struct {
-	context     context.Context
-	client      *ethclient.Client
-	rpcClient   *rpc.Client
-	cmd         *exec.Cmd
-	cancel      context.CancelFunc
-	args        []string
-	rpcURL      string
+	context          context.Context
+	client           *ethclient.Client
+	rpcClient        *rpc.Client
+	cmd              *exec.Cmd
+	cancel           context.CancelFunc
+	args             []string
+	rpcURL           string
 	logger           zerolog.Logger
 	metrics          AnvilMetrics
 	blocksMined      atomic.Uint64
@@ -243,8 +245,8 @@ func (a *Anvil) RPCClient() *rpc.Client {
 }
 
 // Accounts returns the default test accounts with their private keys and addresses.
-// Anvil provides 10 pre-funded test accounts that can be used for testing.
-// Each account starts with 10,000 ETH. Returns an error if any private key cannot be parsed.
+// Anvil provides pre-funded test accounts that can be used for testing.
+// Returns an error if any private key cannot be parsed.
 func (a *Anvil) Accounts() ([len(AnvilPrivateKeys)]*ecdsa.PrivateKey, [len(AnvilPrivateKeys)]common.Address, error) {
 	var (
 		keys     [len(AnvilPrivateKeys)]*ecdsa.PrivateKey
@@ -265,12 +267,11 @@ func (a *Anvil) Accounts() ([len(AnvilPrivateKeys)]*ecdsa.PrivateKey, [len(Anvil
 }
 
 // MineBlock triggers the immediate mining of a new block.
-// This is useful in tests when you need to advance the blockchain state.
-// Returns an error if the RPC call fails.
-func (a *Anvil) MineBlock() error {
+// Returns an error if the RPC call fails or if ctx is canceled.
+func (a *Anvil) MineBlock(ctx context.Context) error {
 	a.blocksMined.Add(1)
 	a.rpcCalls.Add(1)
-	err := a.rpcClient.Call(nil, "evm_mine")
+	err := a.rpcClient.CallContext(ctx, nil, "evm_mine")
 	if err != nil {
 		a.logger.Error().Err(err).Msg("Failed to mine block")
 	}
@@ -279,10 +280,11 @@ func (a *Anvil) MineBlock() error {
 
 // SetNextBlockTimestamp sets the timestamp for the next block to be mined.
 // This only affects the next block; subsequent blocks will use normal timestamps.
-// The timestamp is in Unix seconds. Returns an error if the RPC call fails.
-func (a *Anvil) SetNextBlockTimestamp(timestamp int64) error {
+// The timestamp is in Unix seconds.
+// Returns an error if the RPC call fails or if ctx is canceled.
+func (a *Anvil) SetNextBlockTimestamp(ctx context.Context, timestamp int64) error {
 	a.rpcCalls.Add(1)
-	err := a.rpcClient.Call(nil, "evm_setNextBlockTimestamp", timestamp)
+	err := a.rpcClient.CallContext(ctx, nil, "evm_setNextBlockTimestamp", timestamp)
 	if err != nil {
 		a.logger.Error().Err(err).Int64("timestamp", timestamp).Msg("Failed to set next block timestamp")
 	}
@@ -291,10 +293,10 @@ func (a *Anvil) SetNextBlockTimestamp(timestamp int64) error {
 
 // IncreaseTime increases the current block time by the specified number of seconds.
 // This affects all future blocks and is useful for testing time-dependent contracts.
-// Returns an error if the RPC call fails.
-func (a *Anvil) IncreaseTime(seconds int64) error {
+// Returns an error if the RPC call fails or if ctx is canceled.
+func (a *Anvil) IncreaseTime(ctx context.Context, seconds int64) error {
 	a.rpcCalls.Add(1)
-	err := a.rpcClient.Call(nil, "evm_increaseTime", seconds)
+	err := a.rpcClient.CallContext(ctx, nil, "evm_increaseTime", seconds)
 	if err != nil {
 		a.logger.Error().Err(err).Int64("seconds", seconds).Msg("Failed to increase time")
 	}
@@ -302,11 +304,10 @@ func (a *Anvil) IncreaseTime(seconds int64) error {
 }
 
 // SetBalance sets the balance of an account to the specified amount in Wei.
-// This is useful for testing scenarios that require specific account balances.
-// Returns an error if the RPC call fails.
-func (a *Anvil) SetBalance(address common.Address, balance *big.Int) error {
+// Returns an error if the RPC call fails or if ctx is canceled.
+func (a *Anvil) SetBalance(ctx context.Context, address common.Address, balance *big.Int) error {
 	a.rpcCalls.Add(1)
-	err := a.rpcClient.Call(nil, "anvil_setBalance", address, balance.String())
+	err := a.rpcClient.CallContext(ctx, nil, "anvil_setBalance", address, balance.String())
 	if err != nil {
 		a.logger.Error().Err(err).Str("address", address.Hex()).Str("balance", balance.String()).Msg("Failed to set balance")
 	}
@@ -314,11 +315,11 @@ func (a *Anvil) SetBalance(address common.Address, balance *big.Int) error {
 }
 
 // Impersonate enables impersonating an account, allowing transactions to be sent
-// from that address without needing the private key. This is useful for testing
-// interactions with existing contracts or accounts. Returns an error if the RPC call fails.
-func (a *Anvil) Impersonate(address common.Address) error {
+// from that address without needing the private key.
+// Returns an error if the RPC call fails or if ctx is canceled.
+func (a *Anvil) Impersonate(ctx context.Context, address common.Address) error {
 	a.rpcCalls.Add(1)
-	err := a.rpcClient.Call(nil, "anvil_impersonateAccount", address)
+	err := a.rpcClient.CallContext(ctx, nil, "anvil_impersonateAccount", address)
 	if err != nil {
 		a.logger.Error().Err(err).Str("address", address.Hex()).Msg("Failed to impersonate account")
 	}
@@ -326,11 +327,10 @@ func (a *Anvil) Impersonate(address common.Address) error {
 }
 
 // StopImpersonating stops impersonating an account that was previously impersonated.
-// After calling this, transactions from the address will require a valid signature again.
-// Returns an error if the RPC call fails.
-func (a *Anvil) StopImpersonating(address common.Address) error {
+// Returns an error if the RPC call fails or if ctx is canceled.
+func (a *Anvil) StopImpersonating(ctx context.Context, address common.Address) error {
 	a.rpcCalls.Add(1)
-	err := a.rpcClient.Call(nil, "anvil_stopImpersonatingAccount", address)
+	err := a.rpcClient.CallContext(ctx, nil, "anvil_stopImpersonatingAccount", address)
 	if err != nil {
 		a.logger.Error().Err(err).Str("address", address.Hex()).Msg("Failed to stop impersonating account")
 	}
@@ -338,13 +338,12 @@ func (a *Anvil) StopImpersonating(address common.Address) error {
 }
 
 // Snapshot creates a snapshot of the current blockchain state and returns a snapshot ID.
-// The snapshot can be reverted to using the Revert method. This is useful for testing
-// scenarios where you need to test multiple paths from the same state.
-// Returns the snapshot ID string and an error if the RPC call fails.
-func (a *Anvil) Snapshot() (string, error) {
+// The snapshot can be reverted to using the Revert method.
+// Returns the snapshot ID string and an error if the RPC call fails or if ctx is canceled.
+func (a *Anvil) Snapshot(ctx context.Context) (string, error) {
 	a.rpcCalls.Add(1)
 	var snapshotID string
-	err := a.rpcClient.Call(&snapshotID, "evm_snapshot")
+	err := a.rpcClient.CallContext(ctx, &snapshotID, "evm_snapshot")
 	if err != nil {
 		a.logger.Error().Err(err).Msg("Failed to create snapshot")
 	}
@@ -353,11 +352,11 @@ func (a *Anvil) Snapshot() (string, error) {
 
 // Revert reverts the blockchain state to a previously created snapshot.
 // The snapshot ID should be obtained from a previous Snapshot() call.
-// Returns true if the revert was successful, false otherwise, and an error if the RPC call fails.
-func (a *Anvil) Revert(snapshotID string) (bool, error) {
+// Returns true if the revert was successful and an error if the RPC call fails or if ctx is canceled.
+func (a *Anvil) Revert(ctx context.Context, snapshotID string) (bool, error) {
 	a.rpcCalls.Add(1)
 	var success bool
-	err := a.rpcClient.Call(&success, "evm_revert", snapshotID)
+	err := a.rpcClient.CallContext(ctx, &success, "evm_revert", snapshotID)
 	if err != nil {
 		a.logger.Error().Err(err).Str("snapshotID", snapshotID).Msg("Failed to revert to snapshot")
 	}
@@ -365,11 +364,10 @@ func (a *Anvil) Revert(snapshotID string) (bool, error) {
 }
 
 // SetCode sets the bytecode at a given address.
-// This is useful for deploying contracts at specific addresses or modifying existing contract code.
-// Returns an error if the RPC call fails.
-func (a *Anvil) SetCode(address common.Address, code string) error {
+// Returns an error if the RPC call fails or if ctx is canceled.
+func (a *Anvil) SetCode(ctx context.Context, address common.Address, code string) error {
 	a.rpcCalls.Add(1)
-	err := a.rpcClient.Call(nil, "anvil_setCode", address, code)
+	err := a.rpcClient.CallContext(ctx, nil, "anvil_setCode", address, code)
 	if err != nil {
 		a.logger.Error().Err(err).Str("address", address.Hex()).Msg("Failed to set code")
 	}
@@ -378,10 +376,10 @@ func (a *Anvil) SetCode(address common.Address, code string) error {
 
 // SetStorageAt sets the storage value at a specific slot for an address.
 // The slot and value should be 32-byte hex strings with 0x prefix.
-// Returns an error if the RPC call fails.
-func (a *Anvil) SetStorageAt(address common.Address, slot string, value string) error {
+// Returns an error if the RPC call fails or if ctx is canceled.
+func (a *Anvil) SetStorageAt(ctx context.Context, address common.Address, slot string, value string) error {
 	a.rpcCalls.Add(1)
-	err := a.rpcClient.Call(nil, "anvil_setStorageAt", address, slot, value)
+	err := a.rpcClient.CallContext(ctx, nil, "anvil_setStorageAt", address, slot, value)
 	if err != nil {
 		a.logger.Error().Err(err).
 			Str("address", address.Hex()).
@@ -393,11 +391,10 @@ func (a *Anvil) SetStorageAt(address common.Address, slot string, value string) 
 }
 
 // SetNonce sets the nonce for a given address.
-// This is useful for testing scenarios that require specific nonce values.
-// Returns an error if the RPC call fails.
-func (a *Anvil) SetNonce(address common.Address, nonce uint64) error {
+// Returns an error if the RPC call fails or if ctx is canceled.
+func (a *Anvil) SetNonce(ctx context.Context, address common.Address, nonce uint64) error {
 	a.rpcCalls.Add(1)
-	err := a.rpcClient.Call(nil, "anvil_setNonce", address, fmt.Sprintf("0x%x", nonce))
+	err := a.rpcClient.CallContext(ctx, nil, "anvil_setNonce", address, fmt.Sprintf("0x%x", nonce))
 	if err != nil {
 		a.logger.Error().Err(err).Str("address", address.Hex()).Uint64("nonce", nonce).Msg("Failed to set nonce")
 	}
@@ -405,19 +402,18 @@ func (a *Anvil) SetNonce(address common.Address, nonce uint64) error {
 }
 
 // Mine mines multiple blocks at once.
-// The numBlocks parameter specifies how many blocks to mine.
-// If timestamp is 0, blocks will use incremental timestamps. Otherwise, the first block
-// will use the specified timestamp and subsequent blocks will increment from there.
-// Returns an error if the RPC call fails.
-func (a *Anvil) Mine(numBlocks uint64, timestamp uint64) error {
+// The numBlocks parameter specifies how many blocks to mine. If timestamp is 0, blocks use incremental timestamps.
+// Otherwise the first block uses the given timestamp and subsequent blocks increment from there.
+// Returns an error if the RPC call fails or if ctx is canceled.
+func (a *Anvil) Mine(ctx context.Context, numBlocks uint64, timestamp uint64) error {
 	a.rpcCalls.Add(1)
 	a.blocksMined.Add(numBlocks)
 
 	var err error
 	if timestamp != 0 {
-		err = a.rpcClient.Call(nil, "anvil_mine", fmt.Sprintf("0x%x", numBlocks), fmt.Sprintf("0x%x", timestamp))
+		err = a.rpcClient.CallContext(ctx, nil, "anvil_mine", fmt.Sprintf("0x%x", numBlocks), fmt.Sprintf("0x%x", timestamp))
 	} else {
-		err = a.rpcClient.Call(nil, "anvil_mine", fmt.Sprintf("0x%x", numBlocks))
+		err = a.rpcClient.CallContext(ctx, nil, "anvil_mine", fmt.Sprintf("0x%x", numBlocks))
 	}
 
 	if err != nil {
@@ -428,10 +424,10 @@ func (a *Anvil) Mine(numBlocks uint64, timestamp uint64) error {
 
 // DropTransaction removes a transaction from the memory pool.
 // The transaction hash should be a hex string with 0x prefix.
-// Returns an error if the RPC call fails or if the transaction is not found.
-func (a *Anvil) DropTransaction(txHash string) error {
+// Returns an error if the RPC call fails or if ctx is canceled.
+func (a *Anvil) DropTransaction(ctx context.Context, txHash string) error {
 	a.rpcCalls.Add(1)
-	err := a.rpcClient.Call(nil, "anvil_dropTransaction", txHash)
+	err := a.rpcClient.CallContext(ctx, nil, "anvil_dropTransaction", txHash)
 	if err != nil {
 		a.logger.Error().Err(err).Str("txHash", txHash).Msg("Failed to drop transaction")
 	}
@@ -439,11 +435,11 @@ func (a *Anvil) DropTransaction(txHash string) error {
 }
 
 // SetAutomine enables or disables automatic mining of blocks.
-// When disabled, blocks must be mined manually using MineBlock() or Mine().
-// Returns an error if the RPC call fails.
-func (a *Anvil) SetAutomine(enabled bool) error {
+// When disabled, blocks must be mined manually using MineBlock or Mine.
+// Returns an error if the RPC call fails or if ctx is canceled.
+func (a *Anvil) SetAutomine(ctx context.Context, enabled bool) error {
 	a.rpcCalls.Add(1)
-	err := a.rpcClient.Call(nil, "evm_setAutomine", enabled)
+	err := a.rpcClient.CallContext(ctx, nil, "evm_setAutomine", enabled)
 	if err != nil {
 		a.logger.Error().Err(err).Bool("enabled", enabled).Msg("Failed to set automine")
 	}
@@ -451,11 +447,11 @@ func (a *Anvil) SetAutomine(enabled bool) error {
 }
 
 // SetIntervalMining sets the mining behavior to interval mining with the specified interval in seconds.
-// Set to 0 to disable interval mining. When enabled, blocks are mined automatically at the specified interval.
-// Returns an error if the RPC call fails.
-func (a *Anvil) SetIntervalMining(seconds uint64) error {
+// Set to 0 to disable interval mining.
+// Returns an error if the RPC call fails or if ctx is canceled.
+func (a *Anvil) SetIntervalMining(ctx context.Context, seconds uint64) error {
 	a.rpcCalls.Add(1)
-	err := a.rpcClient.Call(nil, "evm_setIntervalMining", seconds)
+	err := a.rpcClient.CallContext(ctx, nil, "evm_setIntervalMining", seconds)
 	if err != nil {
 		a.logger.Error().Err(err).Uint64("seconds", seconds).Msg("Failed to set interval mining")
 	}
@@ -463,11 +459,10 @@ func (a *Anvil) SetIntervalMining(seconds uint64) error {
 }
 
 // AutoImpersonate enables or disables automatic impersonation for all transactions.
-// When enabled, all transactions are automatically impersonated without needing to call Impersonate.
-// Returns an error if the RPC call fails.
-func (a *Anvil) AutoImpersonate(enabled bool) error {
+// Returns an error if the RPC call fails or if ctx is canceled.
+func (a *Anvil) AutoImpersonate(ctx context.Context, enabled bool) error {
 	a.rpcCalls.Add(1)
-	err := a.rpcClient.Call(nil, "anvil_autoImpersonateAccount", enabled)
+	err := a.rpcClient.CallContext(ctx, nil, "anvil_autoImpersonateAccount", enabled)
 	if err != nil {
 		a.logger.Error().Err(err).Bool("enabled", enabled).Msg("Failed to set auto impersonate")
 	}
@@ -476,20 +471,20 @@ func (a *Anvil) AutoImpersonate(enabled bool) error {
 
 // ResetFork resets the fork to a fresh state, optionally at a new block number.
 // If blockNumber is 0, resets to the original fork block or latest block.
-// Returns an error if the RPC call fails or if not in forked mode.
-func (a *Anvil) ResetFork(forkURL string, blockNumber uint64) error {
+// Returns an error if the RPC call fails or if ctx is canceled.
+func (a *Anvil) ResetFork(ctx context.Context, forkURL string, blockNumber uint64) error {
 	a.rpcCalls.Add(1)
 
 	var err error
 	if blockNumber != 0 {
-		err = a.rpcClient.Call(nil, "anvil_reset", map[string]any{
+		err = a.rpcClient.CallContext(ctx, nil, "anvil_reset", map[string]any{
 			"forking": map[string]any{
 				"jsonRpcUrl":  forkURL,
 				"blockNumber": fmt.Sprintf("0x%x", blockNumber),
 			},
 		})
 	} else {
-		err = a.rpcClient.Call(nil, "anvil_reset", map[string]any{
+		err = a.rpcClient.CallContext(ctx, nil, "anvil_reset", map[string]any{
 			"forking": map[string]any{
 				"jsonRpcUrl": forkURL,
 			},
@@ -579,40 +574,40 @@ func (a *Anvil) Metrics() AnvilMetrics {
 // On the first call, it takes a snapshot of the initial state.
 // On subsequent calls, it reverts to that snapshot and takes a new one.
 // This is much faster than restarting the process.
-// Returns an error if the RPC call fails.
-func (a *Anvil) ResetState() error {
+// Returns an error if the RPC call fails or if ctx is canceled.
+func (a *Anvil) ResetState(ctx context.Context) error {
 	var initErr error
-	
+
 	// Take initial snapshot on first call
 	a.snapshotInitOnce.Do(func() {
-		a.initialSnapshot, initErr = a.Snapshot()
+		a.initialSnapshot, initErr = a.Snapshot(ctx)
 		if initErr != nil {
 			a.logger.Error().Err(initErr).Msg("Failed to take initial snapshot")
 		}
 	})
-	
+
 	if initErr != nil {
 		return initErr
 	}
-	
+
 	// Revert to initial snapshot
-	success, err := a.Revert(a.initialSnapshot)
+	success, err := a.Revert(ctx, a.initialSnapshot)
 	if err != nil {
 		a.logger.Error().Err(err).Msg("Failed to revert to initial snapshot")
 		return err
 	}
-	
+
 	if !success {
 		return fmt.Errorf("failed to revert to initial snapshot")
 	}
-	
+
 	// Take a new snapshot for next reset
-	a.initialSnapshot, err = a.Snapshot()
+	a.initialSnapshot, err = a.Snapshot(ctx)
 	if err != nil {
 		a.logger.Error().Err(err).Msg("Failed to take new snapshot after reset")
 		return err
 	}
-	
+
 	return nil
 }
 

--- a/anvil_test.go
+++ b/anvil_test.go
@@ -1,6 +1,7 @@
 package anvil
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"testing"
@@ -21,18 +22,17 @@ func getTestPort() string {
 	return fmt.Sprintf("%d", testPort)
 }
 
-// setupSharedAnvil creates or reuses a shared Anvil instance and resets its state
+// setupSharedAnvil creates or reuses a shared Anvil instance and resets its state.
 func setupSharedAnvil(t *testing.T, shared *Anvil) *Anvil {
-	// Reset state before each test
 	if shared != nil {
-		err := shared.ResetState()
+		err := shared.ResetState(t.Context())
 		require.NoError(t, err)
 	}
 	return shared
 }
 
-// setupTestAnvil creates a new Anvil instance with custom configuration
-// Use this only for tests that need specific settings (block time, fork, etc.)
+// setupTestAnvil creates a new Anvil instance with custom configuration.
+// Use this only for tests that need specific settings (block time, fork, etc.).
 func setupTestAnvil(t *testing.T, opts ...func(*AnvilBuilder)) *Anvil {
 	builder := NewAnvilBuilder().
 		WithLogLevel(zerolog.Disabled).
@@ -75,6 +75,7 @@ func TestAnvil(t *testing.T) {
 	})
 
 	t.Run("Basic Anvil Operations", func(t *testing.T) {
+		ctx := t.Context()
 		anvil := setupTestAnvil(t, func(b *AnvilBuilder) {
 			b.WithBlockTime("1")
 		})
@@ -83,16 +84,16 @@ func TestAnvil(t *testing.T) {
 		require.NotNil(t, client)
 
 		// Get initial block number
-		initialBlockNum, err := client.BlockNumber(anvil.context)
+		initialBlockNum, err := client.BlockNumber(ctx)
 		require.NoError(t, err)
 
 		// Mine exactly one block
-		err = anvil.MineBlock()
+		err = anvil.MineBlock(ctx)
 		require.NoError(t, err)
 
 		// Wait for block to be mined
 		err = retry(5, time.Second, func() error {
-			currentBlock, err := client.BlockNumber(anvil.context)
+			currentBlock, err := client.BlockNumber(ctx)
 			if err != nil {
 				return err
 			}
@@ -108,6 +109,7 @@ func TestAnvil(t *testing.T) {
 	})
 
 	t.Run("Test Account Management", func(t *testing.T) {
+		ctx := t.Context()
 		anvil := setupSharedAnvil(t, sharedAnvil)
 
 		// Get accounts
@@ -117,30 +119,31 @@ func TestAnvil(t *testing.T) {
 		assert.Len(t, keys, len(AnvilPrivateKeys))
 
 		// Check balance of first account
-		balance, err := anvil.Client().BalanceAt(anvil.context, addresses[0], nil)
+		balance, err := anvil.Client().BalanceAt(ctx, addresses[0], nil)
 		require.NoError(t, err)
 		assert.True(t, balance.Cmp(big.NewInt(0)) > 0)
 	})
 
 	t.Run("Test Time Manipulation", func(t *testing.T) {
+		ctx := t.Context()
 		anvil := setupSharedAnvil(t, sharedAnvil)
 
 		// Get current block
-		block, err := anvil.Client().BlockByNumber(anvil.context, nil)
+		block, err := anvil.Client().BlockByNumber(ctx, nil)
 		require.NoError(t, err)
 		initialTime := block.Time()
 
 		// Increase time by 3600 seconds (1 hour)
-		err = anvil.IncreaseTime(3600)
+		err = anvil.IncreaseTime(ctx, 3600)
 		require.NoError(t, err)
 
 		// Mine a new block to see the time change
-		err = anvil.MineBlock()
+		err = anvil.MineBlock(ctx)
 		require.NoError(t, err)
 
 		time.Sleep(time.Second * 2) // Wait for block to be mined
 
-		newBlock, err := anvil.Client().BlockByNumber(anvil.context, nil)
+		newBlock, err := anvil.Client().BlockByNumber(ctx, nil)
 		require.NoError(t, err)
 		newTime := newBlock.Time()
 
@@ -151,6 +154,7 @@ func TestAnvil(t *testing.T) {
 	})
 
 	t.Run("Test Balance Manipulation", func(t *testing.T) {
+		ctx := t.Context()
 		anvil := setupSharedAnvil(t, sharedAnvil)
 
 		_, addresses, err := anvil.Accounts()
@@ -158,31 +162,32 @@ func TestAnvil(t *testing.T) {
 		testAddr := addresses[0]
 
 		newBalance := big.NewInt(123456789)
-		err = anvil.SetBalance(testAddr, newBalance)
+		err = anvil.SetBalance(ctx, testAddr, newBalance)
 		require.NoError(t, err)
 
-		err = anvil.MineBlock()
+		err = anvil.MineBlock(ctx)
 		require.NoError(t, err)
 
 		time.Sleep(time.Second * 2) // Wait for block to be mined
 
-		balance, err := anvil.Client().BalanceAt(anvil.context, testAddr, nil)
+		balance, err := anvil.Client().BalanceAt(ctx, testAddr, nil)
 		require.NoError(t, err)
 		assert.Equal(t, newBalance.String(), balance.String())
 	})
 
 	t.Run("Test Account Impersonation", func(t *testing.T) {
+		ctx := t.Context()
 		anvil := setupSharedAnvil(t, sharedAnvil)
 
 		testAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
 
-		err := anvil.SetBalance(testAddr, big.NewInt(1000000000000000000))
+		err := anvil.SetBalance(ctx, testAddr, big.NewInt(1000000000000000000))
 		require.NoError(t, err)
 
-		err = anvil.Impersonate(testAddr)
+		err = anvil.Impersonate(ctx, testAddr)
 		require.NoError(t, err)
 
-		err = anvil.StopImpersonating(testAddr)
+		err = anvil.StopImpersonating(ctx, testAddr)
 		require.NoError(t, err)
 
 		metrics := anvil.Metrics()
@@ -190,6 +195,7 @@ func TestAnvil(t *testing.T) {
 	})
 
 	t.Run("Test Builder Options", func(t *testing.T) {
+		ctx := t.Context()
 		anvil := setupTestAnvil(t, func(b *AnvilBuilder) {
 			b.WithBlockTime("2").
 				WithChainID("1337").
@@ -200,81 +206,84 @@ func TestAnvil(t *testing.T) {
 		client := anvil.Client()
 		require.NotNil(t, client)
 
-		_, err := client.BlockNumber(anvil.context)
+		_, err := client.BlockNumber(ctx)
 		require.NoError(t, err)
 	})
 
 	t.Run("Test ResetState", func(t *testing.T) {
+		ctx := t.Context()
 		anvil := setupSharedAnvil(t, sharedAnvil)
 
 		// Get initial block number
-		initialBlock, err := anvil.Client().BlockNumber(anvil.context)
+		initialBlock, err := anvil.Client().BlockNumber(ctx)
 		require.NoError(t, err)
 
 		// Mine blocks
 		for i := 0; i < 3; i++ {
-			err = anvil.MineBlock()
+			err = anvil.MineBlock(ctx)
 			require.NoError(t, err)
 		}
 
 		time.Sleep(time.Second)
 
 		// Verify blocks were mined
-		currentBlock, err := anvil.Client().BlockNumber(anvil.context)
+		currentBlock, err := anvil.Client().BlockNumber(ctx)
 		require.NoError(t, err)
 		assert.Greater(t, currentBlock, initialBlock, "Blocks should have been mined")
 
 		// Reset state
-		err = anvil.ResetState()
+		err = anvil.ResetState(ctx)
 		require.NoError(t, err)
 
 		time.Sleep(time.Second)
 
 		// Verify state was reset
-		newBlock, err := anvil.Client().BlockNumber(anvil.context)
+		newBlock, err := anvil.Client().BlockNumber(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, initialBlock, newBlock, "Block number should be reset to initial state")
 	})
 
 	t.Run("Test Snapshot and Revert", func(t *testing.T) {
+		ctx := t.Context()
 		anvil := setupSharedAnvil(t, sharedAnvil)
 
 		// Get initial state
-		initialBlock, err := anvil.Client().BlockNumber(anvil.context)
+		initialBlock, err := anvil.Client().BlockNumber(ctx)
 		require.NoError(t, err)
 
 		// Create snapshot
-		snapshotID, err := anvil.Snapshot()
+		snapshotID, err := anvil.Snapshot(ctx)
 		require.NoError(t, err)
 		assert.NotEmpty(t, snapshotID)
 
 		// Make changes
-		err = anvil.MineBlock()
+		err = anvil.MineBlock(ctx)
 		require.NoError(t, err)
-		err = anvil.MineBlock()
+		err = anvil.MineBlock(ctx)
 		require.NoError(t, err)
 
 		time.Sleep(time.Second)
 
 		// Verify changes
-		changedBlock, err := anvil.Client().BlockNumber(anvil.context)
+		changedBlock, err := anvil.Client().BlockNumber(ctx)
 		require.NoError(t, err)
 		assert.Greater(t, changedBlock, initialBlock)
 
 		// Revert to snapshot
-		success, err := anvil.Revert(snapshotID)
+		success, err := anvil.Revert(ctx, snapshotID)
 		require.NoError(t, err)
 		assert.True(t, success)
 
 		time.Sleep(time.Second)
 
 		// Verify revert
-		revertedBlock, err := anvil.Client().BlockNumber(anvil.context)
+		revertedBlock, err := anvil.Client().BlockNumber(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, initialBlock, revertedBlock)
 	})
 
 	t.Run("Test SetNonce", func(t *testing.T) {
+		ctx := t.Context()
 		anvil := setupSharedAnvil(t, sharedAnvil)
 
 		_, addresses, err := anvil.Accounts()
@@ -282,28 +291,29 @@ func TestAnvil(t *testing.T) {
 		testAddr := addresses[0]
 
 		// Set nonce
-		err = anvil.SetNonce(testAddr, 42)
+		err = anvil.SetNonce(ctx, testAddr, 42)
 		require.NoError(t, err)
 
 		// Verify nonce
-		nonce, err := anvil.Client().NonceAt(anvil.context, testAddr, nil)
+		nonce, err := anvil.Client().NonceAt(ctx, testAddr, nil)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(42), nonce)
 	})
 
 	t.Run("Test Mine Multiple Blocks", func(t *testing.T) {
+		ctx := t.Context()
 		anvil := setupSharedAnvil(t, sharedAnvil)
 
-		initialBlock, err := anvil.Client().BlockNumber(anvil.context)
+		initialBlock, err := anvil.Client().BlockNumber(ctx)
 		require.NoError(t, err)
 
 		// Mine 5 blocks
-		err = anvil.Mine(5, 0)
+		err = anvil.Mine(ctx, 5, 0)
 		require.NoError(t, err)
 
 		time.Sleep(time.Second)
 
-		newBlock, err := anvil.Client().BlockNumber(anvil.context)
+		newBlock, err := anvil.Client().BlockNumber(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, initialBlock+5, newBlock)
 
@@ -312,44 +322,48 @@ func TestAnvil(t *testing.T) {
 	})
 
 	t.Run("Test Mine With Timestamp", func(t *testing.T) {
+		ctx := t.Context()
 		anvil := setupSharedAnvil(t, sharedAnvil)
 
 		futureTimestamp := uint64(time.Now().Unix() + 3600) //nolint:gosec // Unix timestamp is always positive
-		err := anvil.Mine(1, futureTimestamp)
+		err := anvil.Mine(ctx, 1, futureTimestamp)
 		require.NoError(t, err)
 
 		time.Sleep(time.Second)
 
-		block, err := anvil.Client().BlockByNumber(anvil.context, nil)
+		block, err := anvil.Client().BlockByNumber(ctx, nil)
 		require.NoError(t, err)
 		assert.GreaterOrEqual(t, block.Time(), futureTimestamp)
 	})
 
 	t.Run("Test SetAutomine", func(t *testing.T) {
+		ctx := t.Context()
 		anvil := setupSharedAnvil(t, sharedAnvil)
 
 		// Disable automine
-		err := anvil.SetAutomine(false)
+		err := anvil.SetAutomine(ctx, false)
 		require.NoError(t, err)
 
 		// Re-enable automine
-		err = anvil.SetAutomine(true)
+		err = anvil.SetAutomine(ctx, true)
 		require.NoError(t, err)
 	})
 
 	t.Run("Test SetIntervalMining", func(t *testing.T) {
+		ctx := t.Context()
 		anvil := setupSharedAnvil(t, sharedAnvil)
 
 		// Set interval mining to 1 second
-		err := anvil.SetIntervalMining(1)
+		err := anvil.SetIntervalMining(ctx, 1)
 		require.NoError(t, err)
 
 		// Disable interval mining
-		err = anvil.SetIntervalMining(0)
+		err = anvil.SetIntervalMining(ctx, 0)
 		require.NoError(t, err)
 	})
 
 	t.Run("Test SetCode", func(t *testing.T) {
+		ctx := t.Context()
 		anvil := setupSharedAnvil(t, sharedAnvil)
 
 		_, addresses, err := anvil.Accounts()
@@ -358,16 +372,17 @@ func TestAnvil(t *testing.T) {
 
 		// Set some bytecode (simple contract bytecode)
 		bytecode := "0x6080604052348015600f57600080fd5b50603f80601d6000396000f3fe6080604052600080fdfea264697066735822122012345678901234567890123456789012345678901234567890123456789012345678901264736f6c63430008130033"
-		err = anvil.SetCode(testAddr, bytecode)
+		err = anvil.SetCode(ctx, testAddr, bytecode)
 		require.NoError(t, err)
 
 		// Verify code is set
-		code, err := anvil.Client().CodeAt(anvil.context, testAddr, nil)
+		code, err := anvil.Client().CodeAt(ctx, testAddr, nil)
 		require.NoError(t, err)
 		assert.NotEmpty(t, code)
 	})
 
 	t.Run("Test SetStorageAt", func(t *testing.T) {
+		ctx := t.Context()
 		anvil := setupSharedAnvil(t, sharedAnvil)
 
 		_, addresses, err := anvil.Accounts()
@@ -378,7 +393,7 @@ func TestAnvil(t *testing.T) {
 		slot := "0x0000000000000000000000000000000000000000000000000000000000000000"
 		value := "0x0000000000000000000000000000000000000000000000000000000000000001"
 
-		err = anvil.SetStorageAt(testAddr, slot, value)
+		err = anvil.SetStorageAt(ctx, testAddr, slot, value)
 		require.NoError(t, err)
 
 		// Note: Verifying storage requires the address to have code (be a contract)
@@ -386,26 +401,28 @@ func TestAnvil(t *testing.T) {
 	})
 
 	t.Run("Test AutoImpersonate", func(t *testing.T) {
+		ctx := t.Context()
 		anvil := setupSharedAnvil(t, sharedAnvil)
 
 		// Enable auto impersonate
-		err := anvil.AutoImpersonate(true)
+		err := anvil.AutoImpersonate(ctx, true)
 		require.NoError(t, err)
 
 		// Disable auto impersonate
-		err = anvil.AutoImpersonate(false)
+		err = anvil.AutoImpersonate(ctx, false)
 		require.NoError(t, err)
 	})
 
 	t.Run("Test Metrics Tracking", func(t *testing.T) {
+		ctx := t.Context()
 		anvil := setupSharedAnvil(t, sharedAnvil)
 
 		// Perform several operations
-		err := anvil.MineBlock()
+		err := anvil.MineBlock(ctx)
 		require.NoError(t, err)
 
 		_, addresses, _ := anvil.Accounts()
-		err = anvil.SetBalance(addresses[0], big.NewInt(1000))
+		err = anvil.SetBalance(ctx, addresses[0], big.NewInt(1000))
 		require.NoError(t, err)
 
 		// Check metrics
@@ -449,5 +466,26 @@ func TestAnvil(t *testing.T) {
 
 		err = anvil.Stop()
 		require.NoError(t, err)
+	})
+
+	// WaitForMemPoolEmpty smoke test — idle mempool should return immediately.
+	t.Run("Test WaitForMemPoolEmpty", func(t *testing.T) {
+		ctx := t.Context()
+		anvil := setupSharedAnvil(t, sharedAnvil)
+
+		err := anvil.WaitForMemPoolEmpty(ctx, 2*time.Second)
+		require.NoError(t, err)
+	})
+
+	// WaitForMemPoolEmpty respects ctx cancellation.
+	t.Run("Test WaitForMemPoolEmpty ctx cancel", func(t *testing.T) {
+		anvil := setupSharedAnvil(t, sharedAnvil)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel() // immediately canceled
+
+		err := anvil.WaitForMemPoolEmpty(ctx, 5*time.Second)
+		require.Error(t, err)
+		require.ErrorIs(t, err, context.Canceled)
 	})
 }

--- a/helpers.go
+++ b/helpers.go
@@ -8,10 +8,42 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
+// WaitForMemPoolEmpty waits for the memory pool to be empty (no pending transactions).
+// It polls every 100ms until the pool is empty, ctx is canceled, or the timeout expires —
+// whichever comes first. A zero or negative timeout means "use ctx's deadline only."
+// Returns an error if the timeout is exceeded, ctx is canceled, or the query fails.
+func (a *Anvil) WaitForMemPoolEmpty(ctx context.Context, timeout time.Duration) error {
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("waiting for empty mempool: %w", ctx.Err())
+		case <-ticker.C:
+			pending, err := a.client.PendingTransactionCount(ctx)
+			if err != nil {
+				return fmt.Errorf("query pending transaction count: %w", err)
+			}
+			if pending == 0 {
+				return nil
+			}
+		}
+	}
+}
+
 // MemPoolEmpty waits for the memory pool to be empty (no pending transactions).
-// It polls every 100ms for up to 5 seconds. This is useful in tests when you need
-// to ensure all transactions have been processed before proceeding.
-// Returns an error if the timeout is exceeded or if querying pending transactions fails.
+// It polls every 100ms for up to 5 seconds.
+//
+// Deprecated: Use (*Anvil).WaitForMemPoolEmpty instead. The method honors the
+// ctx deadline directly, accepts a configurable timeout, and uses the instance's
+// own client rather than a passed-in one.
 func MemPoolEmpty(ctx context.Context, client *ethclient.Client) error {
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()


### PR DESCRIPTION
Phase 2 PR C — the largest breaking change in the roadmap. Every mutating RPC wrapper now takes \`context.Context\` as its first parameter, so callers can enforce per-call deadlines and cancellation.

## Summary

**Breaking (pre-1.0; will bump the next minor tag):**
- 18 methods gain a leading \`ctx context.Context\`: \`MineBlock\`, \`SetNextBlockTimestamp\`, \`IncreaseTime\`, \`SetBalance\`, \`Impersonate\`, \`StopImpersonating\`, \`Snapshot\`, \`Revert\`, \`SetCode\`, \`SetStorageAt\`, \`SetNonce\`, \`Mine\`, \`DropTransaction\`, \`SetAutomine\`, \`SetIntervalMining\`, \`AutoImpersonate\`, \`ResetFork\`, \`ResetState\`.
- Internal calls migrated from \`rpcClient.Call(nil, ...)\` to \`rpcClient.CallContext(ctx, ...)\`.
- \`EthereumTestEnvironment\` interface updated to match.

**Additive:**
- \`(*Anvil).WaitForMemPoolEmpty(ctx, timeout)\` — method variant that honors both ctx and an explicit timeout; uses the instance's own client.

**Deprecated:**
- Free function \`MemPoolEmpty(ctx, client)\` — kept as a shim for one release with \`// Deprecated:\` godoc tag.

**Docs updated:**
- \`CHANGELOG.md\` — Changed / Added / Deprecated sections with a migration snippet.
- \`CLAUDE.md\` — replaced the "pending migration" note with the current API shape and a template for new RPC wrappers.
- \`README.md\` — Quick Start and every Usage Examples snippet updated to pass \`ctx\`.

## Migration

\`\`\`go
// before
anvil.MineBlock()
anvil.SetBalance(addr, bal)
snapshotID, _ := anvil.Snapshot()

// after
ctx := context.Background() // or t.Context() in tests, or ctx with a timeout
anvil.MineBlock(ctx)
anvil.SetBalance(ctx, addr, bal)
snapshotID, _ := anvil.Snapshot(ctx)
\`\`\`

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run ./...\` — **0 issues**
- [x] \`go test -race ./...\` — green locally, 30s, against anvil 1.5.0 (includes 2 new WaitForMemPoolEmpty subtests: success path + ctx-cancel path)
- [x] CI: all three jobs (test / vuln / lint) green on the matrix

## Scope notes

- Pre-existing examples outside this repo will need to add \`ctx\` arguments — the one migration snippet above covers the transformation.
- \`WaitForBlock\` already takes a \`timeout\` and constructs its own ctx internally; its signature is **unchanged**.
- Pure Go getters (\`Client\`, \`RPCClient\`, \`Metrics\`, \`Accounts\`) do **not** take ctx — they don't call RPC.
- Lifecycle methods (\`Start\`, \`Stop\`, \`Close\`) are unchanged.

Closes #36
Closes #39

## Follow-ups in this phase

- PR D (Phase 2 polish): \`#37\` readiness probe, \`#38\` stdout routing, \`#40\` anvil executable check, \`#41\` interface decision.
- PR E: \`#42\` CI matrix + codecov, \`#43\` examples/ folder (examples can now be written against the final API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)