### PR TITLE
ci: matrix (ubuntu + macos) × (go 1.25 + 1.26); upload coverage to codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,19 @@ permissions:
 
 jobs:
   test:
-    name: test (race detector)
-    runs-on: ubuntu-latest
+    name: test (${{ matrix.os }} / go ${{ matrix.go }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        go: ['1.25', '1.26']
     steps:
       - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: ${{ matrix.go }}
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -28,8 +33,16 @@ jobs:
       - name: Verify anvil
         run: anvil --version
 
-      - name: go test -race
-        run: go test -race -v ./...
+      - name: go test -race (with coverage)
+        run: go test -race -v -coverprofile=coverage.out -covermode=atomic ./...
+
+      - name: Upload coverage to Codecov
+        if: matrix.os == 'ubuntu-latest' && matrix.go == '1.26'
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
   vuln:
     name: govulncheck
@@ -39,7 +52,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -55,7 +68,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # go-anvil
 
 [![CI](https://github.com/neverDefined/go-anvil/workflows/CI/badge.svg)](https://github.com/neverDefined/go-anvil/actions)
+[![codecov](https://codecov.io/gh/neverDefined/go-anvil/branch/main/graph/badge.svg)](https://codecov.io/gh/neverDefined/go-anvil)
 [![Go Report Card](https://goreportcard.com/badge/github.com/neverDefined/go-anvil)](https://goreportcard.com/report/github.com/neverDefined/go-anvil)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
Last Phase 2 PR. Scope scoped down from the original plan — \`examples/\` folder and godoc \`Example\` functions dropped per maintainer direction (#43 closed as not-planned). Existing README usage examples and the integration test suite are the documentation surface.

## Summary

**CI matrix** in \`.github/workflows/ci.yml\`:
- \`test\` job: \`strategy.matrix: os: [ubuntu-latest, macos-latest] × go: ['1.25', '1.26']\`, \`fail-fast: false\` so one slot failing doesn't mask the others.
- Coverage generated on every slot (\`-coverprofile=coverage.out -covermode=atomic\`) but **only uploaded from the primary slot** (ubuntu + 1.26) to avoid double-counting.
- \`vuln\` and \`lint\` jobs bumped to Go 1.26 for consistency.

**Codecov** via \`codecov/codecov-action@v5\`:
- \`fail_ci_if_error: false\` — a Codecov outage won't block merges.
- Reads \`CODECOV_TOKEN\` secret if set; falls back to tokenless upload for public repos.
- Codecov badge added to README.

## Setup needed on your side (optional but recommended)

1. Visit <https://codecov.io>, sign in with GitHub, enable \`neverDefined/go-anvil\`.
2. Copy the upload token and add it as the \`CODECOV_TOKEN\` secret under \`Settings → Secrets and variables → Actions\`.

Without step 2, uploads still work for public repos but may rate-limit. With it, they're reliable.

## Test plan

- [x] CI runs 4 matrix slots (ubuntu+1.25, ubuntu+1.26, macos+1.25, macos+1.26); all four pass.
- [x] \`vuln\` and \`lint\` jobs green.
- [x] Codecov upload step succeeds (or fails silently if you haven't enabled codecov yet — non-blocking).
- [x] README codecov badge renders.

## Scope notes

- No code changes; this PR is pure CI + README.
- Windows not in the matrix — Foundry's Windows support is weak and not worth the CI maintenance cost.
- #43 (\`examples/\` + godoc \`Example\` functions) closed as not-planned.

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)