### PR TITLE
docs: add .claude/ agents and slash commands for maintainer workflow

### DIFF
--- a/.claude/agents/anvil-reviewer.md
+++ b/.claude/agents/anvil-reviewer.md
@@ -1,0 +1,45 @@
+---
+name: anvil-reviewer
+description: Review a PR or working-tree diff against go-anvil repo conventions. Use before merging a PR, or as a self-check before committing.
+tools: Bash, Read, Grep, Glob
+---
+
+You are reviewing changes to the `go-anvil` library. The library wraps Foundry's `anvil` local EVM node for Go programs. Flag convention violations directly; skip style pedantry that `golangci-lint` already enforces.
+
+## Must-check conventions
+
+**Context-first RPC methods.** Every mutating RPC wrapper takes `ctx context.Context` as its first parameter and forwards via `a.rpcClient.CallContext(ctx, ...)`. A regression to bare `a.rpcClient.Call(nil, ...)` is a hard no-merge — flag it with the file:line and the corrected shape.
+
+**Shared-anvil test pattern.** New test subtests should use `setupSharedAnvil(t, sharedAnvil)` unless they need custom builder config (then `setupTestAnvil(t, opts...)`). A subtest that calls `anvil.NewAnvil()` directly instead of using the helpers is a regression — flag it.
+
+**Error wrapping.** Errors wrap with `fmt.Errorf("...: %w", err)`. If you see `%v` for an error, or a wholly new ad-hoc message that discards an underlying error, flag it. Prefer the sentinel errors at the top of `anvil.go` when they apply.
+
+**Godoc on exports.** Every exported identifier has a godoc comment starting with the identifier name. `revive` in `.golangci.yml` enforces this — but flag missing godoc in review anyway so the author fixes it before CI.
+
+**RPC-method template.** New RPC wrappers must match the shape documented in `CLAUDE.md`: `rpcCalls.Add(1)`, `CallContext(ctx, ...)`, `a.logger.Error().Err(err)...Msg("Failed to ...")`, return err. Deviations are only OK with a clear reason in the PR body.
+
+**Startup lifecycle.** `context.WithCancel` in `Build` and the `//nolint:gosec` on that line are intentional — the cancel is invoked in `Stop()`. Any change that removes the `//nolint` or moves the cancel without preserving the invariant is a bug.
+
+## Procedure
+
+1. Identify the base branch (usually `main`). Run `git diff origin/main...HEAD --stat` to scope the review.
+2. Read each changed file.
+3. Check each convention above. For each violation: file:line reference, what's wrong, concrete fix.
+4. Skim `CLAUDE.md` for conventions not listed here (it's the source of truth).
+5. Check that CHANGELOG.md has an entry if the change is user-visible.
+
+## Output
+
+Produce a focused markdown review:
+
+- **Blockers** (must fix before merge): convention violations or obvious bugs.
+- **Suggestions** (nice-to-have): clearer names, smaller diffs, test additions.
+- **Looks good**: one sentence acknowledging what the PR got right.
+
+Keep the review under 400 words unless the PR is genuinely large.
+
+## Out of scope
+
+- Style nits caught by `golangci-lint` / `gofumpt` / `revive`.
+- Speculative refactors not asked for by the issue the PR closes.
+- Security review (use the dedicated security-review skill for that).

--- a/.claude/agents/release-drafter.md
+++ b/.claude/agents/release-drafter.md
@@ -1,0 +1,69 @@
+---
+name: release-drafter
+description: Walk git log since the last tag and draft the CHANGELOG entry + GitHub release notes. Use when preparing a release cut.
+tools: Bash, Read, Edit
+---
+
+You are preparing release notes for the `go-anvil` library.
+
+## Procedure
+
+1. **Find the base.** Run `git describe --tags --abbrev=0 2>/dev/null` to get the last tag. If no tag exists, this is the first release — use the repo's first commit as the base.
+
+2. **Collect commits.** `git log <base>..HEAD --no-merges --pretty=format:'%h %s'` — merge commits are noise; the real content is in the merged commits.
+
+3. **Group by Conventional Commits type:**
+   - `feat:` / `feat(scope):` → **Added**
+   - `feat!:` / `BREAKING CHANGE:` footer → **Changed** with `**BREAKING:**` prefix
+   - `fix:` → **Fixed**
+   - `refactor:` user-visible → **Changed**
+   - `chore(deps):` bumps → **Changed** with "dependency" grouping, one line summarising (don't list every Dependabot PR)
+   - `chore:` / `ci:` / `docs:` / `test:` → usually **omit** unless user-visible. Maintainer-only churn doesn't belong in release notes.
+   - `deprecated:` or explicit `// Deprecated:` tags in the code → **Deprecated**
+   - Removed exports → **Removed**
+
+4. **Write the CHANGELOG entry.** Edit `CHANGELOG.md`:
+   - Under `## [Unreleased]`, consolidate the existing bullets with any new ones from commits not yet in the list.
+   - Add a new `## [<version>] - <YYYY-MM-DD>` heading above `[Unreleased]`.
+   - Move the consolidated bullets into the new version heading.
+   - Leave `[Unreleased]` empty (ready for the next cycle).
+   - Update the link-reference block at the file bottom: add `[<version>]: https://github.com/neverDefined/go-anvil/releases/tag/v<version>`.
+
+5. **Draft GitHub release notes** (don't push, just print). Format:
+
+   ```markdown
+   ## What's new
+
+   <one-sentence summary of the release theme>
+
+   ### Added
+   - bullet
+
+   ### Changed
+   - bullet
+   - **BREAKING:** bullet — with migration note inline
+
+   ### Fixed
+   - bullet
+
+   ### Deprecated
+   - bullet
+
+   ---
+
+   **Full changelog:** https://github.com/neverDefined/go-anvil/compare/v<prev>...v<new>
+   ```
+
+6. **If breaking changes exist**, add an `## Upgrade guide` section to the release notes with concrete before/after code snippets.
+
+## Output
+
+1. The diff you applied to `CHANGELOG.md` (just confirmation — the user can see the file).
+2. The full GitHub release-notes markdown, ready to paste into `gh release create`.
+
+## Guidelines
+
+- Don't invent entries. If a commit's subject is unclear, open the diff with `git show <sha>`.
+- Don't list every trivial commit. The release notes are for users, not a git log dump.
+- Preserve the existing CHANGELOG section that pre-dates this release — don't rewrite history.
+- If the version bump is ambiguous (feat? fix? breaking?), ask before writing.

--- a/.claude/commands/bump-foundry.md
+++ b/.claude/commands/bump-foundry.md
@@ -1,0 +1,50 @@
+---
+description: Check for a newer stable Foundry release and draft the ci.yml bump (plus optional PR).
+---
+
+Check if there's a newer stable Foundry release than the version pinned in CI. If so, draft the one-line `ci.yml` change and optionally open a PR.
+
+## Steps
+
+1. **Find the pinned version:**
+   ```
+   grep -E 'foundry-toolchain' -A 2 .github/workflows/ci.yml | grep -E 'version:'
+   ```
+   Parse out the `v<semver>`.
+
+2. **List recent stable tags from the Foundry repo** (filter out pre-releases like `-rc1`):
+   ```
+   gh api repos/foundry-rs/foundry/tags --paginate --jq '.[] | .name' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -10
+   ```
+
+3. **Compare.** If the top tag (lexically / semver-wise) is **greater** than the pinned version, propose the bump. If it's equal, say so and stop — don't open a no-op PR.
+
+4. **Print the diff** to the user:
+   ```
+   -          version: v<old>
+   +          version: v<new>
+   ```
+
+   Include a link to the Foundry release notes so the user can eyeball breaking changes:
+   `https://github.com/foundry-rs/foundry/releases/tag/v<new>`
+
+5. **Ask** whether to open a PR. If yes:
+   - `git checkout -b chore/bump-foundry-<new>`
+   - Edit `.github/workflows/ci.yml` with the single line change.
+   - Commit:
+     ```
+     chore(ci): bump Foundry v<old> -> v<new>
+
+     Release notes: https://github.com/foundry-rs/foundry/releases/tag/v<new>
+     ```
+   - `git push -u origin chore/bump-foundry-<new>`
+   - `gh pr create` with a body that links to the release notes and confirms CI verified the bump is safe (it will, when it runs).
+
+   Don't merge. The user reviews the PR.
+
+## Guidelines
+
+- Strict-semver filtering only — no `-rc`, `-beta`, `nightly-*` tags.
+- If the gh API is rate-limited, fall back to `gh release list --repo foundry-rs/foundry --limit 20 --json tagName,isPrerelease`.
+- If the Foundry release notes call out a breaking RPC change, **surface that prominently** in the PR body so the user can skim before merging.
+- Don't open a PR if you can't verify the new version actually differs from what's pinned — show the comparison first.

--- a/.claude/commands/new-rpc.md
+++ b/.claude/commands/new-rpc.md
@@ -1,0 +1,71 @@
+---
+description: Scaffold a new RPC wrapper method on *Anvil, plus a minimal test stub.
+---
+
+Scaffold a new RPC method following the go-anvil repo convention. The shape is documented in `CLAUDE.md`: context-first signature, `rpcCalls.Add(1)`, `CallContext`, error logged and returned, godoc starting with the method name.
+
+## Arguments
+
+`$ARGUMENTS` — expected format: `<MethodName> <rpc_method_name> [<signature-hint>]`
+
+Examples:
+- `/new-rpc SetCoinbase anvil_setCoinbase "address common.Address"`
+- `/new-rpc GetAutomine evm_getAutomine` — zero-arg method
+- `/new-rpc SetChainId anvil_setChainId "chainID uint64"`
+
+If arguments are missing, ask the user for:
+1. The Go method name (PascalCase)
+2. The JSON-RPC method string (the exact name anvil/evm exposes)
+3. Parameters — name and Go type for each
+4. Return type — usually `error`; specify if the RPC has a meaningful result
+
+## Steps
+
+1. Parse `$ARGUMENTS` into method name, rpc name, and parameter list.
+2. Read `anvil.go` and pick the insertion point — group with the closest existing method semantically (all the `Set*` methods are together, mining methods are together, etc.).
+3. Write the method:
+
+   ```go
+   // <MethodName> <one-line purpose>.
+   // Returns an error if the RPC call fails or if ctx is canceled.
+   func (a *Anvil) <MethodName>(ctx context.Context, <params>) error {
+       a.rpcCalls.Add(1)
+       if err := a.rpcClient.CallContext(ctx, nil, "<rpc_method_name>", <param-names>); err != nil {
+           a.logger.Error().Err(err).<field-methods>.Msg("Failed to <verb>")
+           return err
+       }
+       return nil
+   }
+   ```
+
+4. **Methods that return a result** (like `Snapshot` returning a snapshot ID, `Revert` returning a bool): adjust signature to `(ctx, ...) (T, error)`, bind the result to a local variable, and pass `&result` to `CallContext`.
+
+5. Add a minimal subtest in `anvil_test.go` under `TestAnvil` following the shared-anvil pattern:
+
+   ```go
+   t.Run("Test <MethodName>", func(t *testing.T) {
+       ctx := t.Context()
+       anvil := setupSharedAnvil(t, sharedAnvil)
+
+       err := anvil.<MethodName>(ctx, <test-args>)
+       require.NoError(t, err)
+   })
+   ```
+
+   If the method returns data, add a `require.NoError(t, err)` plus at least one assertion on the returned value.
+
+6. Also add a subtest in `anvil_unit_test.go` under `TestRPCMethods_sendCorrectMethod`:
+   - Add `"<rpc_method_name>": <result-or-nil>,` to the `results` map at the top of the function.
+   - Add a `t.Run("<MethodName>", func(t *testing.T) { ... })` block that calls the method and asserts `rs.lastCall().Method` matches.
+
+7. Run the checks before handing back:
+   ```
+   go build ./...
+   golangci-lint run ./...
+   go test -race -run 'TestRPCMethods_sendCorrectMethod/<MethodName>' ./...
+   ```
+
+## Out of scope
+
+- Don't invent parameter types you can't verify. If the RPC method isn't documented in [the Foundry book](https://book.getfoundry.sh/reference/anvil/) or a known header comment, ask the user for the signature.
+- Don't commit. Hand the diff back; user will review before committing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,12 +95,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   builder validation, `resolveAnvilPath` with temp-dir fixtures, the `retry` helper,
   `errors.Is` wrapping for every sentinel, and RPC method shape via `httptest`-backed JSON-RPC
   server. Contributors without Foundry can run `go test -run '^Test(AnvilBuilder|ResolveAnvilPath|Retry|SentinelErrors|RPC)' ./...`.
-- Added integration subtests for the startup-timeout path (`ErrStartupTimeout`), ctx-cancelled
+- Added integration subtests for the startup-timeout path (`ErrStartupTimeout`), ctx-canceled
   RPC call, and 50-goroutine concurrent-stress test that exercises atomics and `-race`.
 - Added `fork_test.go` behind a `//go:build fork` tag; reads `ETH_RPC_URL` and skips cleanly
   when unset. Exercises `WithFork` and `WithForkBlockNumber`.
 - Added `anvil_bench_test.go` with `BenchmarkMineBlock`, `BenchmarkSetBalance`,
   `BenchmarkSnapshotRevertCycle`, and `BenchmarkResetState` for tracking RPC-latency regressions.
+
+### Claude Code tooling
+- Added `.claude/agents/anvil-reviewer.md` — subagent that reviews PRs and working-tree diffs
+  against this repo's conventions (context-first RPC methods, shared-anvil test pattern,
+  error wrapping, godoc-on-exports).
+- Added `.claude/agents/release-drafter.md` — subagent that walks `git log` since the last tag
+  and drafts the CHANGELOG entry plus GitHub release notes following Keep-a-Changelog.
+- Added `.claude/commands/new-rpc.md` — slash command scaffolding a new RPC wrapper method on
+  `*Anvil` matching the repo template, plus integration and unit-test stubs.
+- Added `.claude/commands/bump-foundry.md` — slash command that checks for newer stable
+  Foundry releases, drafts the `ci.yml` diff, and optionally opens a PR.
+- `CLAUDE.md` documents the full set.
 
 ### Fixed
 - Duplicate test function "Test Reset Functionality" removed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,17 @@ func (a *Anvil) SetFoo(ctx context.Context, arg T) error {
 
 **CHANGELOG.** User-visible changes go under `## [Unreleased]` in `CHANGELOG.md`, Keep-a-Changelog format.
 
+## Claude Code tools in this repo
+
+Project-specific subagents and slash commands live in `.claude/`. Invoke them instead of reinventing the wheel.
+
+- **`@anvil-reviewer`** (`.claude/agents/anvil-reviewer.md`) — reviews a PR or working-tree diff against the conventions on this page. Use before merging or as a self-check before committing.
+- **`@release-drafter`** (`.claude/agents/release-drafter.md`) — walks `git log` since the last tag and drafts the CHANGELOG entry plus GitHub release notes. Use when preparing a release cut.
+- **`/new-rpc <MethodName> <rpc_method> [<params>]`** (`.claude/commands/new-rpc.md`) — scaffolds a new RPC wrapper on `*Anvil` matching the shape above, plus integration and unit-test stubs.
+- **`/bump-foundry`** (`.claude/commands/bump-foundry.md`) — checks for a newer stable Foundry release than the version pinned in `ci.yml`, drafts the one-line diff, and optionally opens a PR.
+
+Shared permissions live in `.claude/settings.json` (conservative read-only allowlist). Per-machine overrides go in `.claude/settings.local.json` (globally gitignored).
+
 ## Out of scope
 
 - Adding a non-anvil execution client, node type, or unrelated blockchain tooling — this library is anvil-only.


### PR DESCRIPTION
Phase 3 PR G — ships the Claude Code maintainer-productivity layer.

## Summary

Four new markdown files under \`.claude/\`, all picked up automatically by Claude Code:

### Agents (\`.claude/agents/\`)

- **\`anvil-reviewer\`** — reviews a PR or working-tree diff against repo conventions (context-first RPC methods, shared-anvil test pattern, \`%w\` error wrapping, godoc-on-exports, RPC-method template). Use before merging a PR or as a self-check before committing. Invoke via \`@anvil-reviewer\` or the Task tool.
- **\`release-drafter\`** — walks \`git log\` since the last tag, groups commits by Conventional Commits type, and drafts both the CHANGELOG entry (Keep-a-Changelog) and the GitHub release-notes markdown. Handles breaking-change callouts and upgrade-guide sections automatically.

### Commands (\`.claude/commands/\`)

- **\`/new-rpc <MethodName> <rpc_method> [<params>]\`** — scaffolds a new RPC wrapper on \`*Anvil\` matching the template documented in \`CLAUDE.md\`. Adds the method itself, an integration subtest in \`anvil_test.go\`, and an \`httptest\`-backed unit subtest in \`anvil_unit_test.go\`. Runs \`go build\` + \`golangci-lint\` before handing back.
- **\`/bump-foundry\`** — lists recent stable Foundry tags (strict semver, filters out \`-rc\`), compares against the pin in \`ci.yml\`, drafts the one-line diff, optionally opens a PR with release-notes link.

### Docs

- \`CLAUDE.md\` gains a "Claude Code tools in this repo" section listing all four with invocation syntax.
- \`CHANGELOG.md\` gains a "Claude Code tooling" section under \`[Unreleased]\`.

## Test plan

Hand-smoke each tool after merge:

- [ ] \`@anvil-reviewer\` against this PR's diff — should pass (docs-only, no Go code changed, no conventions to violate).
- [ ] \`@release-drafter\` invoked with no last tag — should summarise commits from the beginning of the repo.
- [ ] \`/new-rpc GetAutomine evm_getAutomine\` as a dry run — should scaffold a method stub and tests.
- [ ] \`/bump-foundry\` — should report "already on latest" since \`v1.5.1\` is current.

## Scope notes

- **Hooks carved out.** #49's acceptance criteria also included pre-commit and post-test hooks. Deciding what a hook should *block* vs. *log* (and for whom — just the maintainer or every contributor who clones?) is a separate design call. Carving this out rather than shipping something half-considered. Happy to file a follow-up issue if wanted.
- **Issue #50 (scheduled remote agents) still open** — these run on Anthropic infra and are billed per run. You haven't told me to go ahead; I've left the issue open so we can resolve deliberately.

## What's left after this merges

- #50 — scheduled remote agents (your call: ship, defer, or close)
- #35 — govet shadow check follow-up (low priority)
- #9 — hard-fork scenarios (may partially overlap with \`fork_test.go\` already shipped; needs triage)
- **Deferred**: release automation (goreleaser + first \`v0.1.0\` tag)

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)